### PR TITLE
Bugfix: searching and listing Normal/Superior bases

### DIFF
--- a/src/common/types/Item.ts
+++ b/src/common/types/Item.ts
@@ -1,5 +1,6 @@
 export enum ItemQuality {
   Normal = "Normal",
+  Superior = "Superior",
   Magic = "Magic",
   Rare = "Rare",
   Set = "Set",

--- a/src/hooks/pd2website/useStashCache.ts
+++ b/src/hooks/pd2website/useStashCache.ts
@@ -145,7 +145,9 @@ export function useStashCache(authData, settings) {
        !item.type.includes("Charm")) &&
        (item.quality === ItemQuality.Rare || 
         item.quality === ItemQuality.Magic || 
-        item.quality === ItemQuality.Crafted)) {
+        item.quality === ItemQuality.Crafted ||
+        item.quality === ItemQuality.Normal ||
+        item.quality === ItemQuality.Superior)) {
       
       const typeBaseInfo = getTypeFromBaseType(item.type);
       if (typeBaseInfo) {

--- a/src/pages/price-check/lib/tradeUrlBuilder.ts
+++ b/src/pages/price-check/lib/tradeUrlBuilder.ts
@@ -82,7 +82,9 @@ export function buildTradeUrl(
     if (
       item.quality === ItemQuality.Rare ||
       item.quality === ItemQuality.Magic ||
-      item.quality === ItemQuality.Crafted) {
+      item.quality === ItemQuality.Crafted ||
+      item.quality === ItemQuality.Normal ||
+      item.quality === ItemQuality.Superior) {
       const result = getTypeFromBaseType(item.type, false);
       if (result && result?.type && result?.type) {
         searchParams.set("type", result.type as any);
@@ -213,7 +215,9 @@ export function buildGetMarketListingQuery(
     if (
       item.quality === ItemQuality.Rare ||
       item.quality === ItemQuality.Magic ||
-      item.quality === ItemQuality.Crafted) {
+      item.quality === ItemQuality.Crafted ||
+      item.quality === ItemQuality.Normal ||
+      item.quality === ItemQuality.Superior) {
       const result = getTypeFromBaseType(item.type, true);
       if (result && result?.type && result?.type) {
         let typeValue = result.type;


### PR DESCRIPTION
This PR addresses being unable to search or list normal/superior items as [noted here](https://discord.com/channels/1384698098533666898/1384698731257008199/1388420491118903376).

![image](https://github.com/user-attachments/assets/d3e9f895-eb1f-4c4f-b0dd-c2fae1c072ac)

![image](https://github.com/user-attachments/assets/da6708c8-b74f-4cf3-bfd0-f87e2b878b17)
